### PR TITLE
fix: update logo size

### DIFF
--- a/src/components/Supporter.astro
+++ b/src/components/Supporter.astro
@@ -5,21 +5,22 @@ interface Props {
   url: string;
   alt: string;
   src: ImageMetadata;
+  height?: string;
 }
-const { url, alt, src } = Astro.props;
+const { url, alt, src, height } = Astro.props;
 ---
 
 <a href={url} target="_blank" rel="noreferrer">
   <Image class="image" src={src} alt={alt} />
 </a>
 
-<style>
+<style define:vars={{ height: height ?? '40px' }}>
   a {
-    max-height: 40px;
+    max-height: var(--height);
   }
   .image {
     width: 100%;
     height: auto;
-    max-height: 40px;
+    max-height: var(--height);
   }
 </style>

--- a/src/components/subpages/Footer.astro
+++ b/src/components/subpages/Footer.astro
@@ -30,14 +30,18 @@ const t = useTranslations(lang);
             <Supporter
               url="https://www.ernst-goehner-stiftung.ch"
               src={EGS}
+              height="30px"
               alt="Ernst Göhner Stiftung"
             />
           </div>
-          <Supporter
-            url="https://www.grstiftung.ch/en.html"
-            src={GRS}
-            alt="Gebert Rüf Stiftung"
-          />
+          <div class="single-logo">
+            <Supporter
+              url="https://www.grstiftung.ch/en.html"
+              src={GRS}
+              height="90px"
+              alt="Gebert Rüf Stiftung"
+            />
+          </div>
           <Supporter
             url="https://www.education21.ch/fr"
             src={education21}


### PR DESCRIPTION
Updated logo size, so foundation logos are bigger.

<img width="929" alt="Screenshot 2023-11-02 at 08 18 44" src="https://github.com/graasp/graasp-content-climate/assets/39373170/7a512c42-bfce-4df0-a6b1-172048a97e62">

Since the width of both logos are different, their height are different, but they should look visually as imposing.